### PR TITLE
[feature] add f2 score

### DIFF
--- a/km3net/model/eval.py
+++ b/km3net/model/eval.py
@@ -154,4 +154,5 @@ def evaluate(y_true, y_pred, y_score, train_losses, valid_losses, model):
     print('ROC AUC: %.3f' % roc_auc)
     print('Precision Recall AUC: %.3f' % pr_auc)
     print('F1 Score: %.3f' % skmetrics.f1_score(y_true, y_pred))
+    print('F2 Score: %.3f' % skmetrics.fbeta_score(y_true, y_pred, beta=2.0))
 


### PR DESCRIPTION
For skewed datasets, when minimizing the false negatives is
important (which is the case in this project), the f2 score is a
better metric compared to the f1 score.